### PR TITLE
deps: Typst v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ memmap2 = "0.7"
 same-file = "1"
 siphasher = "0.3"
 tar = "0.4"
-typst = { git = "https://github.com/typst/typst", version = "0.8.0" }
-typst-library = { git = "https://github.com/typst/typst", version = "0.8.0" }
+typst = { git = "https://github.com/typst/typst", version = "0.9.0" }
+typst-library = { git = "https://github.com/typst/typst", version = "0.9.0" }
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt/", version = "0.2.5" }
 ureq = "2"
 walkdir = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typster"
 description = "Library provides a way to compile and format Typst documents, and update PDF metadata."
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["kaoru <k@warpnine.io>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ ecow = "0.2"
 env_proxy = "0.4"
 filetime = "0.2"
 flate2 = "1"
-memmap2 = "0.7"
+fontdb = "0.15.0"
 same-file = "1"
 siphasher = "0.3"
 tar = "0.4"
@@ -31,7 +31,6 @@ typst = { git = "https://github.com/typst/typst", version = "0.9.0" }
 typst-library = { git = "https://github.com/typst/typst", version = "0.9.0" }
 typstfmt_lib = { git = "https://github.com/astrale-sharp/typstfmt/", version = "0.2.5" }
 ureq = "2"
-walkdir = "2"
 
 # PDF metadata management
 lopdf = "0.31.0"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,19 @@ Naive Rust Library which provides a way to work with [Typst](https://typst.app/)
    | Modification date | Modified                       | Modification date                  |
    | Custom properties | Custom Properties              | (None)                             |
 
-Note that both creation and modification date are set automatically to the current date _without time information_ (for some privacy reasons, or my preference.)
+Note that:
+
+- All metadata will be overwritten, not merged.
+- Both creation and modification date are set automatically to the current date _without time information_ which means time is always 0:00 UTC, for some privacy reasons (or my preference.)
+
+You can specify some of them with Typst. As of Typst [v0.9.0](https://github.com/typst/typst/releases/tag/v0.9.0), the following metadata is supported:
+
+- Title
+- Author
+- Keywords
+- Date
+
+See [Document Function – Typst Documentation](https://typst.app/docs/reference/meta/document/#parameters-keywords) for details.
 
 ## Crate features
 

--- a/examples/sample.typ
+++ b/examples/sample.typ
@@ -1,6 +1,13 @@
 // Shamelessly copied from https://zenn.dev/monaqa/articles/2023-04-19-typst-introduction
 // Thank you!
 
+#set document(
+  title: "確率論の基礎",
+  author: "typster",
+  keywords: "確率論, 確率空間, 確率測度, 確率質量関数, 可測空間, 可測集合, 事象, Event, 確率, 定理, 定義, 例",
+  date: auto
+)
+
 // --------- ちょっとした設定 ---------
 
 // フォント周り

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,6 +1,9 @@
-use std::time::Duration;
-use std::{fs, path::Path, path::PathBuf};
-use typst::{doc::Document, eval::Tracer, geom::Color, World};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use typst::{doc::Document, eval::Tracer, export, geom::Color, World};
 
 use crate::world::SystemWorld;
 
@@ -72,7 +75,7 @@ fn export_image(
         } else {
             params.output.as_path()
         };
-        let pixmap = typst::export::render(frame, params.ppi.unwrap_or(144.0) / 72.0, Color::WHITE);
+        let pixmap = export::render(frame, params.ppi.unwrap_or(144.0) / 72.0, Color::WHITE);
         pixmap.save_png(path)?;
     }
 
@@ -84,7 +87,6 @@ fn export_pdf(
     document: &Document,
     params: &CompileParams,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let buffer = typst::export::pdf(document);
-    fs::write(&params.output, buffer)?;
+    fs::write(&params.output, export::pdf(document, Some(&params.input.to_string_lossy()), None))?;
     Ok(())
 }

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -1,13 +1,7 @@
-use std::{
-    cell::OnceCell,
-    env,
-    fs::{self, File},
-    path::{Path, PathBuf},
-};
+use std::{cell::OnceCell, fs, path::PathBuf};
 
-use memmap2::Mmap;
+use fontdb::{Database, Source};
 use typst::font::{Font, FontBook, FontInfo, FontStyle};
-use walkdir::WalkDir;
 
 /// Searches for fonts.
 pub struct FontSearcher {
@@ -28,16 +22,24 @@ pub struct FontSlot {
     font: OnceCell<Option<Font>>,
 }
 
-impl FontSlot {
-    /// Get the font for this slot.
-    pub fn get(&self) -> Option<Font> {
-        self.font
-            .get_or_init(|| {
-                let data = fs::read(&self.path).ok()?.into();
-                Font::new(data, self.index)
-            })
-            .clone()
-    }
+/// Information about a font variant. Simply a wrapper around `typst::font::FontVariant`.
+#[derive(Debug)]
+pub struct FontVariant {
+    /// The style of the font (normal / italic / oblique).
+    pub style: FontStyle,
+    /// How heavy the font is (100 - 900).
+    pub weight: String,
+    /// How condensed or expanded the font is (0.5 - 2.0).
+    pub stretch: String,
+}
+
+/// Information about a font. Simply a wrapper around `typst::font::book::FontInfo`.
+#[derive(Debug)]
+pub struct FontInformation {
+    /// The name of the font.
+    pub name: String,
+    /// The variants of the font.
+    pub variants: Vec<FontVariant>,
 }
 
 impl FontSearcher {
@@ -48,11 +50,37 @@ impl FontSearcher {
 
     /// Search everything that is available.
     pub fn search(&mut self, font_paths: &[PathBuf]) {
+        let mut db = Database::new();
+
+        // Font paths have highest priority.
         for path in font_paths {
-            self.search_dir(path)
+            db.load_fonts_dir(path);
         }
 
-        self.search_system();
+        // System fonts have second priority.
+        db.load_system_fonts();
+
+        for face in db.faces() {
+            let path = match &face.source {
+                Source::File(path) | Source::SharedFile(path, _) => path,
+                // We never add binary sources to the database, so there
+                // shouln't be any.
+                Source::Binary(_) => continue,
+            };
+
+            let info = db
+                .with_face_data(face.id, FontInfo::new)
+                .expect("database must contain this font");
+
+            if let Some(info) = info {
+                self.book.push(info);
+                self.fonts.push(FontSlot {
+                    path: path.clone(),
+                    index: face.index,
+                    font: OnceCell::new(),
+                });
+            }
+        }
 
         self.add_embedded();
     }
@@ -127,91 +155,18 @@ impl FontSearcher {
             add!("NotoSerifJP-SemiBold.otf");
         }
     }
-
-    /// Search for fonts in the linux system font directories.
-    fn search_system(&mut self) {
-        if cfg!(target_os = "macos") {
-            self.search_dir("/Library/Fonts");
-            self.search_dir("/Network/Library/Fonts");
-            self.search_dir("/System/Library/Fonts");
-        } else if cfg!(unix) {
-            self.search_dir("/usr/share/fonts");
-            self.search_dir("/usr/local/share/fonts");
-        } else if cfg!(windows) {
-            self.search_dir(
-                env::var_os("WINDIR")
-                    .map(PathBuf::from)
-                    .unwrap_or_else(|| "C:\\Windows".into())
-                    .join("Fonts"),
-            );
-
-            if let Some(roaming) = dirs::config_dir() {
-                self.search_dir(roaming.join("Microsoft\\Windows\\Fonts"));
-            }
-
-            if let Some(local) = dirs::cache_dir() {
-                self.search_dir(local.join("Microsoft\\Windows\\Fonts"));
-            }
-        }
-
-        if let Some(dir) = dirs::font_dir() {
-            self.search_dir(dir);
-        }
-    }
-
-    /// Search for all fonts in a directory recursively.
-    fn search_dir(&mut self, path: impl AsRef<Path>) {
-        for entry in WalkDir::new(path)
-            .follow_links(true)
-            .sort_by(|a, b| a.file_name().cmp(b.file_name()))
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            let path = entry.path();
-            if matches!(
-                path.extension().and_then(|s| s.to_str()),
-                Some("ttf" | "otf" | "TTF" | "OTF" | "ttc" | "otc" | "TTC" | "OTC"),
-            ) {
-                self.search_file(path);
-            }
-        }
-    }
-
-    /// Index the fonts in the file at the given path.
-    fn search_file(&mut self, path: &Path) {
-        if let Ok(file) = File::open(path) {
-            if let Ok(mmap) = unsafe { Mmap::map(&file) } {
-                for (i, info) in FontInfo::iter(&mmap).enumerate() {
-                    self.book.push(info);
-                    self.fonts.push(FontSlot {
-                        path: path.into(),
-                        index: i as u32,
-                        font: OnceCell::new(),
-                    });
-                }
-            }
-        }
-    }
 }
 
-/// Information about a font. Simply a wrapper around `typst::font::book::FontInfo`.
-#[derive(Debug)]
-pub struct FontInformation {
-    /// The name of the font.
-    pub name: String,
-    /// The variants of the font.
-    pub variants: Vec<FontVariant>,
-}
-
-/// Information about a font variant. Simply a wrapper around `typst::font::FontVariant`.
-#[derive(Debug)]
-pub struct FontVariant {
-    /// The style of the font (normal / italic / oblique).
-    pub style: FontStyle,
-    /// How heavy the font is (100 - 900).
-    pub weight: String,
-    /// How condensed or expanded the font is (0.5 - 2.0).
-    pub stretch: String,
+impl FontSlot {
+    /// Get the font for this slot.
+    pub fn get(&self) -> Option<Font> {
+        self.font
+            .get_or_init(|| {
+                let data = fs::read(&self.path).ok()?.into();
+                Font::new(data, self.index)
+            })
+            .clone()
+    }
 }
 
 impl From<&FontInfo> for FontVariant {


### PR DESCRIPTION
[Release Version 0.9.0 (October 31, 2023) · typst/typst](https://github.com/typst/typst/releases/tag/v0.9.0)

- fix: update compile fn to adopt Typst 0.9.0
- docs: add note for props
- examples: update Typst example to set some metadata
- feat: update font handling per Typst 0.9.0
- release: v0.12.0
