### PR TITLE
refactor: clean-ups for publishing (BREAKING CHANGES)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,8 @@ path = "src/lib.rs"
 chrono = { version = "0.4.35", default-features = false, features = ["clock", "std"], optional = true }
 comemo = { version = "0.4.0", optional = true }
 dirs = { version = "5.0.1", optional = true }
-ecow = { version = "0.2.1", optional = true }
+ecow = { version = "0.2.1", features = ["serde"], optional = true }
 env_proxy = { version = "0.4.1", optional = true }
-filetime = { version = "0.2.23", optional = true }
 flate2 = { version = "1.0.28", optional = true }
 fontdb = { version = "0.16.2", optional = true }
 same-file = { version = "1.0.6", optional = true }
@@ -32,7 +31,6 @@ typst = { version = "0.11.0", optional = true }
 typst-assets = { version = "0.11.0", features = ["fonts"], optional = true }
 typst-pdf = { version = "0.11.0", optional = true }
 typst-render = { version = "0.11.0", optional = true }
-typst-assets = { version = "0.11.0", features = ["fonts"], optional = true }
 typst-timing = { version = "0.11.0", optional = true }
 ureq = { version = "2.9.6", optional = true }
 
@@ -52,17 +50,17 @@ serde = { version = "1.0.197", features = ["derive"] }
 
 # Watch server
 axum = { version = "0.7.4", features = ["ws"], optional = true }
-tokio = { version = "1.36.0", features = ["rt-multi-thread", "net", "fs", "signal", "macros"], optional = true }
 notify = { version = "6.1.1", optional = true }
+tokio = { version = "1.36.0", features = ["fs", "macros", "net", "rt-multi-thread", "signal"], optional = true }
 
 # Open in browser
-open = { version = "5.1.2", optional = true }
 once_cell = "1.19.0"
+open = { version = "5.1.2", optional = true }
 parking_lot = "0.12.1"
 
 [build-dependencies]
-toml = "0.8.11"
 serde = { version = "1.0.197", features = ["derive"] }
+toml = "0.8.11"
 
 [dev-dependencies]
 sha2 = "0.10.8"
@@ -71,11 +69,11 @@ tokio = { version = "1.36.0", features = ["net"] }
 [features]
 full = [
     "compile",
-    "format",
-    "pdf_permission",
-    "pdf_metadata",
-    "watch",
     "embed_additional_fonts",
+    "format",
+    "pdf_metadata",
+    "pdf_permission",
+    "watch",
 ]
 
 # Enable these features to select capabilities.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ You can update PDF metadata. Following metadata is supported:
 >
 > - All metadata will be overwritten, not merged.
 > - Both creation and modification date are set automatically to the current date
+    >
     _without
+    >
     time
+    >
     information_ which means time is always 0:00 UTC, for some privacy reasons (or my preference.)
 
 You can specify some of them with Typst. As of Typst [v0.11.0](https://github.com/typst/typst/releases/tag/v0.11.0), the following metadata is supported:
@@ -137,15 +140,12 @@ Note that you have to install `exiftool` to run all tests.
 
 - The crate itself is licensed under the Apache License version 2.0, as same as [Typst](https://github.com/typst/typst/). See [LICENSE](LICENSE) for details.
 - Fonts under the [assets/fonts](assets/fonts) directory are licensed under its own license.
-
-  | Fonts                                              | License                                                                |
-        | -------------------------------------------------- | ---------------------------------------------------------------------- |
-  | `assets/fonts/ComputerModern/cmunrm.ttf`           | [LICENSE](assets/fonts/ComputerModern/SIL%20Open%20Font%20License.txt) |
-  | `assets/fonts/iAWriterDuo/iAWriterDuoS-*.ttf`      | [LICENSE](assets/fonts/iAWriterDuo/LICENSE.md)                         |
-  | `assets/fonts/NotoSansJP/NotoSansJP-*.ttf`         | [LICENSE](assets/fonts/NotoSansJP/OFL.txt)                             |
-  | `assets/fonts/NotoSerifJP/NotoSerifJP-*.otf`       | [LICENSE](assets/fonts/NotoSerifJP/OFL.txt)                            |
-  | `assets/fonts/Recursive/recursive-static-OTFs.otc` | [LICENSE](assets/fonts/Recursive/OFL.txt)                              |
-  | `assets/fonts/SourceCodePro/SourceCodePro-*.ttf`   | [LICENSE](assets/fonts/SourceCodePro/OFL.txt)                          |
+    - `assets/fonts/ComputerModern/cmunrm.ttf`: [LICENSE](assets/fonts/ComputerModern/SIL%20Open%20Font%20License.txt)
+    - `assets/fonts/iAWriterDuo/iAWriterDuoS-*.ttf`: [LICENSE](assets/fonts/iAWriterDuo/LICENSE.md)
+    - `assets/fonts/NotoSansJP/NotoSansJP-*.ttf`: [LICENSE](assets/fonts/NotoSansJP/OFL.txt)
+    - `assets/fonts/NotoSerifJP/NotoSerifJP-*.otf`: [LICENSE](assets/fonts/NotoSerifJP/OFL.txt)
+    - `assets/fonts/Recursive/recursive-static-OTFs.otc`: [LICENSE](assets/fonts/Recursive/OFL.txt)
+    - `assets/fonts/SourceCodePro/SourceCodePro-*.ttf`: [LICENSE](assets/fonts/SourceCodePro/OFL.txt)
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # typster
 
-Naive Rust Library which provides a way to work with [Typst](https://typst.app/) document and PDF file programmatically.
+A naive Rust library that provides a way to work with [Typst](https://typst.app/) document and PDF file programmatically.
 
 ## Usage
 
@@ -139,7 +139,7 @@ Note that you have to install `exiftool` to run all tests.
 - Fonts under the [assets/fonts](assets/fonts) directory are licensed under its own license.
 
   | Fonts                                              | License                                                                |
-    | -------------------------------------------------- | ---------------------------------------------------------------------- |
+      | -------------------------------------------------- | ---------------------------------------------------------------------- |
   | `assets/fonts/ComputerModern/cmunrm.ttf`           | [LICENSE](assets/fonts/ComputerModern/SIL%20Open%20Font%20License.txt) |
   | `assets/fonts/iAWriterDuo/iAWriterDuoS-*.ttf`      | [LICENSE](assets/fonts/iAWriterDuo/LICENSE.md)                         |
   | `assets/fonts/NotoSansJP/NotoSansJP-*.ttf`         | [LICENSE](assets/fonts/NotoSansJP/OFL.txt)                             |

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ $ cargo run --example update_metadata --features pdf_metadata
 
 You can set PDF permission update. Following PDF 1.7 permissions are supported:
 
-- user password, which is required to open the document. Leave empty to allow anyone to open.
-- owner password, which is required to change permissions. Leave empty to allow anyone to change.
+- user password, which is required to open the document. Set to `None` to allow anyone to open.
+- owner password, which is required to change permissions. Set to `None` to allow anyone to change.
 - content copying for accessibility.
 - page extraction.
 - document assembly.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can update PDF metadata. Following metadata is supported:
     time
     information_ which means time is always 0:00 UTC, for some privacy reasons (or my preference.)
 
-You can specify some of them with Typst. As of Typst [v0.10.0](https://github.com/typst/typst/releases/tag/v0.10.0), the following metadata is supported:
+You can specify some of them with Typst. As of Typst [v0.11.0](https://github.com/typst/typst/releases/tag/v0.11.0), the following metadata is supported:
 
 - Title
 - Author
@@ -139,7 +139,7 @@ Note that you have to install `exiftool` to run all tests.
 - Fonts under the [assets/fonts](assets/fonts) directory are licensed under its own license.
 
   | Fonts                                              | License                                                                |
-      | -------------------------------------------------- | ---------------------------------------------------------------------- |
+        | -------------------------------------------------- | ---------------------------------------------------------------------- |
   | `assets/fonts/ComputerModern/cmunrm.ttf`           | [LICENSE](assets/fonts/ComputerModern/SIL%20Open%20Font%20License.txt) |
   | `assets/fonts/iAWriterDuo/iAWriterDuoS-*.ttf`      | [LICENSE](assets/fonts/iAWriterDuo/LICENSE.md)                         |
   | `assets/fonts/NotoSansJP/NotoSansJP-*.ttf`         | [LICENSE](assets/fonts/NotoSansJP/OFL.txt)                             |

--- a/build.rs
+++ b/build.rs
@@ -45,7 +45,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     // See https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
     write!(
         f,
-        r#"pub fn version() -> &'static str {{ "{typster_version}" }}
+        r#"/// Returns the version of the library.
+pub fn version() -> &'static str {{ "{typster_version}" }}
+
+/// Returns the [Typst](https://typst.app/) version the library was compiled with.
 pub fn typst_version() -> &'static str {{ "{typst_version}" }}
 "#,
     )

--- a/examples/compile.rs
+++ b/examples/compile.rs
@@ -11,7 +11,7 @@ fn main() {
             .join("examples")
             .join("sample.pdf"),
         font_paths: vec!["assets".into()],
-        inputs: vec![("input".to_string(), "value".to_string())],
+        dict: vec![("input".to_string(), "value".to_string())],
         ppi: None,
     };
     match typster::compile(&params) {

--- a/examples/list_fonts.rs
+++ b/examples/list_fonts.rs
@@ -9,7 +9,7 @@ fn main() {
             .join("examples")
             .join("sample.pdf"),
         font_paths: vec![],
-        inputs: vec![("input".to_string(), "value".to_string())],
+        dict: vec![("input".to_string(), "value".to_string())],
         ppi: None,
     };
 

--- a/examples/list_fonts.rs
+++ b/examples/list_fonts.rs
@@ -1,8 +1,6 @@
 use std::path::PathBuf;
 
 fn main() {
-    // equivalent to:
-    //     typst compile examples/sample.typ examples/sample.pdf
     let params = typster::CompileParams {
         input: PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("examples")
@@ -15,12 +13,20 @@ fn main() {
         ppi: None,
     };
 
-    typster::list_fonts(&params.font_paths).iter().for_each(|font| {
-        println!("{}:", font.name);
-        font.variants
-            .iter()
-            .for_each(|typster::FontVariant { style, weight, stretch }| {
-                println!("- Style: {style:?}, Weight: {weight}, Stretch: {stretch}");
-            });
-    });
+    typster::list_fonts(&params.font_paths)
+        .iter()
+        .for_each(|(family, fontinfo)| {
+            let mut sorted = fontinfo
+                .iter()
+                .map(|info| {
+                    (format!("{:?}", info.variant.style), format!("{:?}", info.variant.weight))
+                })
+                .collect::<Vec<_>>();
+            sorted.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+
+            println!("{}:", family);
+            sorted
+                .iter()
+                .for_each(|(style, weight)| println!("  - Style: {style}, Weight: {weight}"));
+        });
 }

--- a/examples/set_permission.rs
+++ b/examples/set_permission.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .join("examples")
             .join("sample-protected.pdf"),
         &PermissionParams {
-            owner_password: "owner".to_string(),
+            owner_password: Some("owner".to_string()),
             allow_print: PrintPermission::None,
             ..Default::default()
         },

--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -12,7 +12,7 @@ fn main() {
             .join("examples")
             .join("sample.pdf"),
         font_paths: vec!["assets".into()],
-        inputs: vec![("input".to_string(), "value".to_string())],
+        dict: vec![("input".to_string(), "value".to_string())],
         ppi: None,
     };
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -11,7 +11,7 @@ use crate::world::SystemWorld;
 /// Parameters for [Typst](https://typst.app/) document compilation.
 #[derive(Debug, Clone, Default)]
 pub struct CompileParams {
-    /// Path to input Typst file.
+    /// Path to input [Typst](https://typst.app/) file.
     pub input: PathBuf,
 
     /// String key-value pairs visible through `sys.inputs` [dictionary](https://typst.app/docs/reference/foundations/dictionary/) in the `input` document.
@@ -24,7 +24,7 @@ pub struct CompileParams {
     /// Adds additional directories to search for fonts.
     pub font_paths: Vec<PathBuf>,
 
-    /// The PPI (pixels per inch) to use for PNG export. None means 144.
+    /// The PPI (pixels per inch) to use for PNG export. [`None`] means 144.
     pub ppi: Option<f32>,
 }
 
@@ -37,6 +37,34 @@ pub struct CompileParams {
 /// # Returns
 ///
 /// Result containing the [`Duration`] of the compilation.
+///
+/// # Example
+///
+/// Following is an example of how to use the `compile` function:
+///
+/// ```rust
+/// let params = typster::CompileParams {
+///     input: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+///         .join("examples")
+///         .join("sample.typ"),
+///     output: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+///         .join("examples")
+///         .join("sample.pdf"),
+///     font_paths: vec!["assets".into()],
+///     dict: vec![("input".to_string(), "value".to_string())],
+///     ppi: None,
+/// };
+/// match typster::compile(&params) {
+///     Ok(duration) => println!("Compilation succeeded in {duration:?}"),
+///     Err(why) => eprintln!("{why}"),
+/// }
+/// ```
+///
+/// which is equivalent to running:
+///
+/// ```console
+/// $ typst compile examples/sample.typ examples/sample.pdf
+/// ```
 pub fn compile(params: &CompileParams) -> Result<Duration, Box<dyn std::error::Error>> {
     let world = SystemWorld::new(&params.input, &params.font_paths, params.dict.clone())
         .map_err(|err| err.to_string())?;

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -8,7 +8,7 @@ use typst::{eval::Tracer, foundations::Smart, model::Document, visualize::Color,
 
 use crate::world::SystemWorld;
 
-/// Parameters for a compilation.
+/// Parameters for Typst document compilation.
 #[derive(Debug, Clone, Default)]
 pub struct CompileParams {
     /// Path to input Typst file.

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -8,7 +8,7 @@ use typst::{eval::Tracer, foundations::Smart, model::Document, visualize::Color,
 
 use crate::world::SystemWorld;
 
-/// Parameters for Typst document compilation.
+/// Parameters for [Typst](https://typst.app/) document compilation.
 #[derive(Debug, Clone, Default)]
 pub struct CompileParams {
     /// Path to input Typst file.
@@ -28,15 +28,15 @@ pub struct CompileParams {
     pub ppi: Option<f32>,
 }
 
-/// Compiles an input file into a supported output format
+/// Compiles an input file into a supported output format.
 ///
 /// # Arguments
 ///
-/// - `params` - CompileParams struct.
+/// - `params` - [`CompileParams`] struct.
 ///
 /// # Returns
 ///
-/// Result containing the core::time::Duration of the compilation.
+/// Result containing the [`Duration`] of the compilation.
 pub fn compile(params: &CompileParams) -> Result<Duration, Box<dyn std::error::Error>> {
     let world = SystemWorld::new(&params.input, &params.font_paths, params.inputs.clone())
         .map_err(|err| err.to_string())?;

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -14,8 +14,8 @@ pub struct CompileParams {
     /// Path to input Typst file.
     pub input: PathBuf,
 
-    /// Inputs map
-    pub inputs: Vec<(String, String)>,
+    /// String key-value pairs visible through `sys.inputs` [dictionary](https://typst.app/docs/reference/foundations/dictionary/) in the `input` document.
+    pub dict: Vec<(String, String)>,
 
     /// Path to output file (PDF, PNG). Output format is determined by extension, and only PNG and
     /// PDF are supported.
@@ -38,7 +38,7 @@ pub struct CompileParams {
 ///
 /// Result containing the [`Duration`] of the compilation.
 pub fn compile(params: &CompileParams) -> Result<Duration, Box<dyn std::error::Error>> {
-    let world = SystemWorld::new(&params.input, &params.font_paths, params.inputs.clone())
+    let world = SystemWorld::new(&params.input, &params.font_paths, params.dict.clone())
         .map_err(|err| err.to_string())?;
     let start = std::time::Instant::now();
 

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -158,7 +158,17 @@ impl FontSearcher {
     }
 }
 
+#[allow(unused_imports)]
+use crate::CompileParams; // For documentation purposes.
+
 /// Lists all fonts available for the library.
+///
+/// Note that:
+///
+/// - typst-cli [defaults](https://github.com/typst/typst-assets/blob/5ca2a6996da97dcba893247576a4a70bbbae8a7a/src/lib.rs#L67-L80)
+///   are always embedded.
+/// - The crate won't search system fonts to ensure the reproducibility. All fonts you need should
+///   be explicitly added via [`CompileParams`].
 ///
 /// # Arguments
 ///

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -158,7 +158,7 @@ impl FontSearcher {
     }
 }
 
-/// List all fonts available for the library.
+/// Lists all fonts available for the library.
 ///
 /// # Arguments
 ///
@@ -166,7 +166,7 @@ impl FontSearcher {
 ///
 /// # Returns
 ///
-/// A list of FontInfo structs.
+/// A [`Vec`] of [`FontInfo`] structs.
 pub fn list_fonts(font_paths: &[PathBuf]) -> HashMap<String, Vec<FontInfo>> {
     let mut searcher = FontSearcher::new();
     searcher.search(font_paths);

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -1,7 +1,7 @@
-use std::{fs, path::PathBuf, sync::OnceLock};
+use std::{collections::HashMap, fs, path::PathBuf, sync::OnceLock};
 
 use fontdb::{Database, Source};
-use typst::text::{Font, FontBook, FontInfo, FontStyle};
+use typst::text::{Font, FontBook, FontInfo};
 
 /// Searches for fonts.
 pub struct FontSearcher {
@@ -20,36 +20,6 @@ pub struct FontSlot {
     index: u32,
     /// The lazily loaded font.
     font: OnceLock<Option<Font>>,
-}
-
-/// Information about a font variant. Simply a wrapper around `typst::font::FontVariant`.
-#[derive(Debug)]
-pub struct FontVariant {
-    /// The style of the font (normal / italic / oblique).
-    pub style: FontStyle,
-    /// How heavy the font is (100 - 900).
-    pub weight: String,
-    /// How condensed or expanded the font is (0.5 - 2.0).
-    pub stretch: String,
-}
-
-impl From<&FontInfo> for FontVariant {
-    fn from(info: &FontInfo) -> Self {
-        Self {
-            style: info.variant.style,
-            weight: format!("{:?}", info.variant.weight),
-            stretch: format!("{:?}", info.variant.stretch),
-        }
-    }
-}
-
-/// Information about a font. Simply a wrapper around `typst::font::book::FontInfo`.
-#[derive(Debug)]
-pub struct FontInformation {
-    /// The name of the font.
-    pub name: String,
-    /// The variants of the font.
-    pub variants: Vec<FontVariant>,
 }
 
 impl FontSlot {
@@ -196,24 +166,13 @@ impl FontSearcher {
 ///
 /// # Returns
 ///
-/// A list of FontInformation structs.
-pub fn list_fonts(font_paths: &[PathBuf]) -> Vec<FontInformation> {
+/// A list of FontInfo structs.
+pub fn list_fonts(font_paths: &[PathBuf]) -> HashMap<String, Vec<FontInfo>> {
     let mut searcher = FontSearcher::new();
     searcher.search(font_paths);
     searcher
         .book
         .families()
-        .map(|(name, infos)| {
-            let mut variants = infos.map(FontVariant::from).collect::<Vec<FontVariant>>();
-
-            variants.sort_by(|a, b| {
-                a.style
-                    .cmp(&b.style)
-                    .then(a.weight.cmp(&b.weight))
-                    .then(a.stretch.cmp(&b.stretch))
-            });
-
-            FontInformation { name: name.to_string(), variants }
-        })
-        .collect::<_>()
+        .map(|(family, infos)| (family.to_string(), infos.cloned().collect::<Vec<FontInfo>>()))
+        .collect::<HashMap<String, Vec<FontInfo>>>()
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -13,11 +13,11 @@ pub struct FormatParams {
     pub column: usize,
 }
 
-/// Format a Typst file.
+/// Formats a [Typst](https://typst.app/) file with [Enter-tainer/typstyle](https://github.com/Enter-tainer/typstyle/).
 ///
-/// # Arguments
+/// # Argument
 ///
-/// - `params` - FormatParams struct.
+/// - `params` - [`FormatParams`] struct.
 ///
 /// # Returns
 ///

--- a/src/format.rs
+++ b/src/format.rs
@@ -22,6 +22,22 @@ pub struct FormatParams {
 /// # Returns
 ///
 /// String containing the formatted Typst file.
+///
+/// # Example
+///
+/// Following is an example of how to use the `format` function:
+///
+/// ```rust
+/// let params = typster::FormatParams {
+///     input: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+///         .join("examples")
+///         .join("sample.typ"),
+///     column: 80,
+/// };
+///
+/// println!("{}", typster::format(&params).map_or_else(|why| why.to_string(), |s| s));
+/// ```
+
 pub fn format(params: &FormatParams) -> Result<String, Box<dyn std::error::Error>> {
     let root = parse(&read_to_string(&params.input)?);
     let disabled_nodes = get_no_format_nodes(root.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub mod tests {
                 .join("sample.typ"),
             output: output.clone(),
             font_paths: vec![],
-            inputs: vec![("input".to_string(), "value".to_string())],
+            dict: vec![("input".to_string(), "value".to_string())],
             ppi: None,
         };
 
@@ -88,7 +88,7 @@ pub mod tests {
                 .join("sample.typ"),
             output: output.clone(),
             font_paths: vec![],
-            inputs: vec![("input".to_string(), "value".to_string())],
+            dict: vec![("input".to_string(), "value".to_string())],
             ppi: None,
         };
 
@@ -228,7 +228,7 @@ $P(A) = sum_(omega in A) h(omega)$ とおけば、 $P$ は確率測度となる�
                 .join("sample.typ"),
             output: output.clone(),
             font_paths: vec![],
-            inputs: vec![("input".to_string(), "value".to_string())],
+            dict: vec![("input".to_string(), "value".to_string())],
             ppi: None,
         };
         assert!(compile(&params).is_ok());
@@ -286,7 +286,7 @@ $P(A) = sum_(omega in A) h(omega)$ とおけば、 $P$ は確率測度となる�
                 .join("sample.typ"),
             output: output.clone(),
             font_paths: vec![],
-            inputs: vec![("input".to_string(), "value".to_string())],
+            dict: vec![("input".to_string(), "value".to_string())],
             ppi: None,
         };
         assert!(compile(&params).is_ok());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+//! A naive Rust Library that provides a way to work with [Typst](https://typst.app/) document and PDF file programmatically.
+
 #[cfg(feature = "compile")]
 pub use compile::{compile, CompileParams};
 #[cfg(feature = "compile")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "compile")]
 pub use compile::{compile, CompileParams};
 #[cfg(feature = "compile")]
-pub use fonts::{list_fonts, FontInformation, FontVariant};
+pub use fonts::list_fonts;
 #[cfg(feature = "format")]
 pub use format::{format, FormatParams};
 #[cfg(feature = "pdf_permission")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,7 @@ $P(A) = sum_(omega in A) h(omega)$ とおけば、 $P$ は確率測度となる�
             output.clone(),
             output_protected.clone(),
             &PermissionParams {
-                owner_password: "owner".to_string(),
+                owner_password: Some("owner".to_string()),
                 allow_print: PrintPermission::None,
                 ..Default::default()
             },

--- a/src/set_permission.rs
+++ b/src/set_permission.rs
@@ -38,6 +38,7 @@ pub struct PermissionParams {
     pub encrypt_metadata: bool,
 }
 
+/// PDF print permission.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PrintPermission {

--- a/src/set_permission.rs
+++ b/src/set_permission.rs
@@ -6,12 +6,12 @@ use serde::{Deserialize, Serialize};
 /// Parameters for PDF permission.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PermissionParams {
-    /// User password, which is required to open the document. Leave empty to allow anyone to open.
-    pub user_password: String,
+    /// User password, which is required to open the document. Set to None to allow anyone to open.
+    pub user_password: Option<String>,
 
-    /// Owner password, which is required to change permissions. Leave empty to allow anyone to
+    /// Owner password, which is required to change permissions. Set to None to allow anyone to
     /// change.
-    pub owner_password: String,
+    pub owner_password: Option<String>,
 
     /// Allow content copying for accessibility.
     pub allow_accessibility: bool,
@@ -83,8 +83,8 @@ impl From<String> for PrintPermission {
 impl From<&PermissionParams> for EncryptionParams {
     fn from(params: &PermissionParams) -> EncryptionParams {
         EncryptionParams::R6(EncryptionParamsR6 {
-            user_password: params.user_password.clone(),
-            owner_password: params.owner_password.clone(),
+            user_password: params.user_password.clone().unwrap_or_default(),
+            owner_password: params.owner_password.clone().unwrap_or_default(),
             allow_accessibility: params.allow_accessibility,
             allow_extract: params.allow_extract,
             allow_assemble: params.allow_assemble,
@@ -100,8 +100,8 @@ impl From<&PermissionParams> for EncryptionParams {
 impl Default for PermissionParams {
     fn default() -> Self {
         Self {
-            user_password: "".to_string(),
-            owner_password: "".to_string(),
+            user_password: None,
+            owner_password: None,
             allow_accessibility: true,
             allow_extract: true,
             allow_assemble: false,

--- a/src/set_permission.rs
+++ b/src/set_permission.rs
@@ -3,7 +3,7 @@ use std::{error::Error, fmt::Display, path::PathBuf};
 use qpdf::{EncryptionParams, EncryptionParamsR6};
 use serde::{Deserialize, Serialize};
 
-/// Parameters for permission.
+/// Parameters for PDF permission.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PermissionParams {
     /// User password, which is required to open the document. Leave empty to allow anyone to open.
@@ -38,7 +38,7 @@ pub struct PermissionParams {
     pub encrypt_metadata: bool,
 }
 
-/// PDF print permission.
+/// PDF print permission for [`PermissionParams`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PrintPermission {
@@ -114,6 +114,13 @@ impl Default for PermissionParams {
     }
 }
 
+/// Sets permission for a PDF file. Note that in-place update is not possible.
+///
+/// # Arguments
+///
+/// - `input` - Path to the PDF file.
+/// - `output` - Path to the output PDF file.
+/// - `params` - [`PermissionParams`] to set.
 pub fn set_permission(
     input: PathBuf,
     output: PathBuf,

--- a/src/set_permission.rs
+++ b/src/set_permission.rs
@@ -6,10 +6,11 @@ use serde::{Deserialize, Serialize};
 /// Parameters for PDF permission.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PermissionParams {
-    /// User password, which is required to open the document. Set to None to allow anyone to open.
+    /// User password, which is required to open the document. Set to [`None`] to allow anyone to
+    /// open.
     pub user_password: Option<String>,
 
-    /// Owner password, which is required to change permissions. Set to None to allow anyone to
+    /// Owner password, which is required to change permissions. Set to [`None`] to allow anyone to
     /// change.
     pub owner_password: Option<String>,
 
@@ -121,6 +122,44 @@ impl Default for PermissionParams {
 /// - `input` - Path to the PDF file.
 /// - `output` - Path to the output PDF file.
 /// - `params` - [`PermissionParams`] to set.
+///
+/// # Example
+///
+/// Following is an example of how to use the `set_permission` function:
+///
+/// ```rust
+/// let output = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+///         .join("examples")
+///         .join("sample.pdf");
+///
+/// // Compile a document first
+/// let params = typster::CompileParams {
+///     input: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+///         .join("examples")
+///         .join("sample.typ"),
+///     output: output.clone(),
+///     font_paths: vec!["assets".into()],
+///     dict: vec![("input".to_string(), "value".to_string())],
+///     ppi: None,
+/// };
+/// match typster::compile(&params) {
+///     Ok(duration) => println!("Compilation succeeded in {duration:?}"),
+///     Err(why) => eprintln!("{why}"),
+/// }
+///
+/// // Then set permission
+/// typster::set_permission(
+///     output,
+///     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+///         .join("examples")
+///         .join("sample-protected.pdf"),
+///     &typster::PermissionParams {
+///         owner_password: Some("owner".to_string()),
+///         allow_print: typster::PrintPermission::None,
+///         ..Default::default()
+///     },
+/// ).unwrap();
+/// ```
 pub fn set_permission(
     input: PathBuf,
     output: PathBuf,

--- a/src/set_permission.rs
+++ b/src/set_permission.rs
@@ -126,6 +126,10 @@ pub fn set_permission(
     output: PathBuf,
     params: &PermissionParams,
 ) -> Result<(), Box<dyn Error>> {
+    // Should be canonicalized before equality check, but output is not created yet.
+    if input == output {
+        return Err("in-place update is not possible".into());
+    }
     qpdf::QPdf::read(input)
         .unwrap()
         .writer()

--- a/src/update_metadata.rs
+++ b/src/update_metadata.rs
@@ -4,7 +4,7 @@ use lopdf::{Dictionary, Document, Object};
 use serde::{Deserialize, Serialize};
 use xmp_toolkit::{xmp_ns, OpenFileOptions, XmpDateTime, XmpFile, XmpMeta, XmpValue};
 
-/// PDF, dublin core, and [Extensible Metadata Platform (XMP)](https://www.adobe.com/devnet/xmp.html) metadata for a document. See also [Extensible Metadata Platform (XMP) Specification: Part 1, Data Model, Serialization, and Core Properties](https://github.com/adobe/XMP-Toolkit-SDK/blob/main/docs/XMPSpecificationPart1.pdf) for detail.
+/// PDF, dublin core, and [Extensible Metadata Platform (XMP)](https://www.adobe.com/devnet/xmp.html) metadata for a PDF document. See also [Extensible Metadata Platform (XMP) Specification: Part 1, Data Model, Serialization, and Core Properties](https://github.com/adobe/XMP-Toolkit-SDK/blob/main/docs/XMPSpecificationPart1.pdf) for detail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PdfMetadata {
     /// Title of the document.
@@ -70,10 +70,60 @@ impl Default for PdfMetadata {
 
 /// Updates the metadata of a PDF file.
 ///
+/// Note that:
+///
+/// - All metadata will be overwritten, not merged.
+/// - Both creation and modification date are set automatically to the current date _without_ time
+///   information_ which means time is always 0:00 UTC, for some privacy reasons (or my preference.)
+///
 /// # Arguments
 ///
 /// - `path` - Path to the PDF file.
 /// - `metadata` - [`PdfMetadata`] to set.
+///
+/// # Example
+///
+/// Following is an example of how to use the `update_metadata` function:
+///
+/// ```rust
+/// let output = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+///     .join("examples")
+///     .join("sample.pdf");
+///
+/// // Compile a document first
+/// let params = typster::CompileParams {
+///     input: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+///         .join("examples")
+///         .join("sample.typ"),
+///     output: output.clone(),
+///     font_paths: vec!["assets".into()],
+///     dict: vec![("input".to_string(), "value".to_string())],
+///     ppi: None,
+/// };
+/// match typster::compile(&params) {
+///     Ok(duration) => println!("Compilation succeeded in {duration:?}"),
+///     Err(why) => eprintln!("{why}"),
+/// }
+///
+/// // Then update metadata
+/// let mut custom_properties = std::collections::HashMap::new();
+/// custom_properties.insert("robots".to_string(), "noindex".to_string());
+/// custom_properties.insert("custom".to_string(), "properties".to_string());
+///
+/// let metadata = typster::PdfMetadata {
+///     title: "Title (typster)".to_string(),
+///     author: "Author (typster)".to_string(),
+///     application: "Application (typster)".to_string(),
+///     subject: "Subject (typster)".to_string(),
+///     copyright_status: true,
+///     copyright_notice: "Copyright notice (typster)".to_string(),
+///     keywords: vec!["typster".to_string(), "rust".to_string(), "pdf".to_string()],
+///     language: "en".to_string(),
+///     custom_properties,
+/// };
+///
+/// typster::update_metadata(&output, &metadata).unwrap();
+/// ```
 pub fn update_metadata(
     path: &Path,
     metadata: &PdfMetadata,

--- a/src/update_metadata.rs
+++ b/src/update_metadata.rs
@@ -4,7 +4,7 @@ use lopdf::{Dictionary, Document, Object};
 use serde::{Deserialize, Serialize};
 use xmp_toolkit::{xmp_ns, OpenFileOptions, XmpDateTime, XmpFile, XmpMeta, XmpValue};
 
-/// PDF, dublin core, and xmp metadata for a document.
+/// PDF, dublin core, and [Extensible Metadata Platform (XMP)](https://www.adobe.com/devnet/xmp.html) metadata for a document. See also [Extensible Metadata Platform (XMP) Specification: Part 1, Data Model, Serialization, and Core Properties](https://github.com/adobe/XMP-Toolkit-SDK/blob/main/docs/XMPSpecificationPart1.pdf) for detail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PdfMetadata {
     /// Title of the document.
@@ -68,12 +68,12 @@ impl Default for PdfMetadata {
     }
 }
 
-/// Update the metadata of a PDF file.
+/// Updates the metadata of a PDF file.
 ///
 /// # Arguments
 ///
 /// - `path` - Path to the PDF file.
-/// - `metadata` - Metadata to set.
+/// - `metadata` - [`PdfMetadata`] to set.
 pub fn update_metadata(
     path: &Path,
     metadata: &PdfMetadata,

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -38,10 +38,11 @@ const EXTENSIONS: [&str; 16] = [
 ];
 
 /// Starts a web server that serves the output PDF file, while watching for changes in the input
-/// Typst file and recompiles when a change is detected. Changes for `typ` file, along with files
-/// with extension `cbor`, `csv`, `gif`, `htm`, `html`, `jpeg`, `jpg`, `json`, `png`, `svg`, `toml`,
-/// `txt`, `xml`, `yaml`, and `yml` in the same directory, recursively, will be watched.
-/// This is inspired by [ItsEthra/typst-live](https://github.com/ItsEthra/typst-live/).
+/// Typst file and recompiles when a change is detected.
+///
+///Changes for `typ` file, along with files with extension `cbor`, `csv`, `gif`, `htm`, `html`,
+/// `jpeg`, `jpg`, `json`, `png`, `svg`, `toml`, `txt`, `xml`, `yaml`, and `yml` in the same
+/// directory, recursively, will be watched. This is inspired by [ItsEthra/typst-live](https://github.com/ItsEthra/typst-live/).
 ///
 /// # Arguments
 ///

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -38,12 +38,15 @@ const EXTENSIONS: [&str; 16] = [
 ];
 
 /// Starts a web server that serves the output PDF file, while watching for changes in the input
-/// Typst file and recompiles when a change is detected.
+/// Typst file and recompiles when a change is detected. Changes for `typ` file, along with files
+/// with extension `cbor`, `csv`, `gif`, `htm`, `html`, `jpeg`, `jpg`, `json`, `png`, `svg`, `toml`,
+/// `txt`, `xml`, `yaml`, and `yml` in the same directory, recursively, will be watched.
+/// This is inspired by [ItsEthra/typst-live](https://github.com/ItsEthra/typst-live/).
 ///
 /// # Arguments
 ///
-/// - `params` - CompileParams struct.
-/// - `open` - Whether to open the output PDF file in the default browser.
+/// - `params` - [`CompileParams`] struct.
+/// - `open` - Whether to open the output PDF file with the default browser.
 pub async fn watch(params: &CompileParams, open: bool) -> Result<(), Box<dyn Error>> {
     let addr = SocketAddr::from(([127, 0, 0, 1], 0));
     let listener = TcpListener::bind(&addr).await?;


### PR DESCRIPTION
- **chore: organize dependencies**
- **refactor: reduce thin wrapper structs**
- **docs: code comments**
- **docs: code comments**
- **refactor: rename to `dict` from `inputs` for clarity (BREAKING CHANGE)**
- **refactor: utilize Option for clarity (BREAKING CHANGE)**
- **refactor: naive in-place editing change**
- **docs: code comments**
- **docs: code comments**
- **docs: Typst version**
- **docs: a table to a list**
