### PR TITLE
release: back to v0.11.0 (BREAKING CHANGE)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typster"
 description = "Library provides a way to compile and format Typst documents, and update PDF metadata."
-version = "1.3.4"
+version = "0.11.0"
 edition = "2021"
 authors = ["kaoru <k@warpnine.io>"]
 license = "MIT"


### PR DESCRIPTION
Since the underlying Typst is still in pre-v1 state, both its interfaces and semantics may change, and so will this crate. I believe I'm the only one who will use this crate as a dependency, so to adhere to semver, let's change the version number from v1.3.2 to v0.11.0 before I (hopefully) publish this on crates.io. Going forward, only the patch number will continue to increase until Typst reaches v1. Old git tags will be renamed with a prefix of `archive-` to signify their historical meanings.
